### PR TITLE
Improve error handling for errors with Ambari API and extra services

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
@@ -41,8 +41,10 @@ import brooklyn.event.basic.MapConfigKey;
 import brooklyn.event.basic.Sensors;
 import brooklyn.util.flags.SetFromFlag;
 import io.brooklyn.ambari.agent.AmbariAgent;
+import io.brooklyn.ambari.rest.AmbariApiException;
 import io.brooklyn.ambari.server.AmbariServer;
 import io.brooklyn.ambari.service.ExtraService;
+import io.brooklyn.ambari.service.ExtraServiceException;
 
 @Catalog(name = "Ambari Cluster", description = "Ambari Cluster: Made up of one or more Ambari Server and One or more Ambari Agents")
 @ImplementedBy(AmbariClusterImpl.class)
@@ -141,12 +143,12 @@ public interface AmbariCluster extends Entity, Startable {
     /**
      * Configure and deploy a new Hadoop cluster on the registered Ambari agents.
      */
-    void deployCluster();
+    void deployCluster() throws AmbariApiException, ExtraServiceException;
 
     /**
      * Call after a the hadoop cluster has been deployed
      */
-    void postDeployCluster();
+    void postDeployCluster() throws ExtraServiceException;
 
     /**
      * Urls for extra stack definitions e.g. Kerberos

--- a/ambari/src/main/java/io/brooklyn/ambari/server/AmbariServer.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/server/AmbariServer.java
@@ -32,6 +32,7 @@ import brooklyn.event.AttributeSensor;
 import brooklyn.event.basic.PortAttributeSensorAndConfigKey;
 import brooklyn.event.basic.Sensors;
 import io.brooklyn.ambari.AmbariNode;
+import io.brooklyn.ambari.rest.AmbariApiException;
 import io.brooklyn.ambari.rest.domain.RecommendationWrapper;
 import io.brooklyn.ambari.rest.domain.RecommendationWrappers;
 import io.brooklyn.ambari.rest.domain.Request;
@@ -71,7 +72,8 @@ public interface AmbariServer extends AmbariNode {
     public RecommendationWrappers getRecommendations(String stackName, String stackVersion, List<String> hosts, List<String> services);
 
     /**
-     * Creates a new blueprint and deploys it, based on the Ambari recommendations.
+     * Creates a new blueprint and deploys it, based on the Ambari recommendations. If an error occurred, the method
+     * will throw an {@link AmbariApiException} for the error to be propagated properly to the tree.
      *
      * @param clusterName           the cluster name to use.
      * @param blueprintName         the blueprint name to use.
@@ -79,7 +81,7 @@ public interface AmbariServer extends AmbariNode {
      * @param config                the additional configuration for the Hadoop services.
      * @return a request corresponding to the Ambari's operation.
      */
-    public Request deployCluster(String clusterName, String blueprintName, RecommendationWrapper recommendationWrapper, Map config);
+    public Request deployCluster(String clusterName, String blueprintName, RecommendationWrapper recommendationWrapper, Map config) throws AmbariApiException;
 
     @Effector(description = "Adds a host to a cluster")
     public void addHostToCluster(@EffectorParam(name = "Cluster name") String cluster,

--- a/ambari/src/main/java/io/brooklyn/ambari/service/ExtraService.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/service/ExtraService.java
@@ -19,15 +19,16 @@
 
 package io.brooklyn.ambari.service;
 
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.reflect.TypeToken;
+
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.ConfigKeys;
 import brooklyn.util.flags.SetFromFlag;
-import com.google.common.reflect.TypeToken;
 import io.brooklyn.ambari.AmbariCluster;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Defines an "extra service" for the Hadoop cluster. An entity implementing this interface will be assured to be called
@@ -57,16 +58,18 @@ public interface ExtraService extends Entity {
     Map<String, Map> getAmbariConfig();
 
     /**
-     * Called just before the hadoop cluster will be deployed.
+     * Called just before the hadoop cluster will be deployed. If an error occurred during this phase, the subclasses
+     * should throw an {@link ExtraServiceException} for the error to be propagated properly to the tree.
      *
      * @param ambariCluster the current Ambari cluster entity.
      */
-    void preClusterDeploy(AmbariCluster ambariCluster);
+    void preClusterDeploy(AmbariCluster ambariCluster) throws ExtraServiceException;
 
     /**
-     * Called just after the hadoop cluster has been deployed.
+     * Called just after the hadoop cluster has been deployed. If an error occurred during this phase, the subclasses
+     * should throw an {@link ExtraServiceException} for the error to be propagated properly to the tree.
      *
      * @param ambariCluster the current Ambari cluster entity.
      */
-    void postClusterDeploy(AmbariCluster ambariCluster);
+    void postClusterDeploy(AmbariCluster ambariCluster) throws ExtraServiceException;
 }

--- a/ambari/src/main/java/io/brooklyn/ambari/service/ExtraServiceException.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/service/ExtraServiceException.java
@@ -16,20 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.brooklyn.ambari.rest;
 
-import java.text.MessageFormat;
+package io.brooklyn.ambari.service;
 
-import retrofit.RetrofitError;
-import retrofit.mime.TypedByteArray;
+public class ExtraServiceException extends RuntimeException {
 
-public class AmbariApiException extends IllegalStateException {
-
-    private static final long serialVersionUID = -4818661501394443750L;
-
-    static final String ERROR_MESSAGE = "Error from the Ambari REST API - HTTP/{0} [{1}]:\n{2}";
-
-    public AmbariApiException(RetrofitError retrofitError) {
-        super(MessageFormat.format(ERROR_MESSAGE, retrofitError.getResponse().getStatus(), retrofitError.getUrl(), new String(((TypedByteArray) retrofitError.getResponse().getBody()).getBytes())));
+    public ExtraServiceException(String message) {
+        super(message);
     }
 }

--- a/ambari/src/test/java/io/brooklyn/ambari/rest/AmbariApiErrorTest.java
+++ b/ambari/src/test/java/io/brooklyn/ambari/rest/AmbariApiErrorTest.java
@@ -34,8 +34,8 @@ public class AmbariApiErrorTest {
 
     @Test
     public void testNameFormat() throws Exception {
-        assertEquals(MessageFormat.format(AmbariApiException.ERROR_MESSAGE, "fdsfs", "Dsfsd"), "Unacceptable Response Code from Ambari Rest API fdsfs\n" +
-                "Message from Server Dsfsd");
+        assertEquals(MessageFormat.format(AmbariApiException.ERROR_MESSAGE, "fdsfs", "Dsfsd", "dsfgdhsh"), "Error from the Ambari REST API - HTTP/fdsfs [Dsfsd]:\n" +
+                "dsfgdhsh");
     }
     
     @Test
@@ -43,7 +43,7 @@ public class AmbariApiErrorTest {
         String content = "mycontent";
         HttpToolResponse httpToolResponse = new HttpToolResponse(456, ImmutableMap.<String, List<String>>of(), content.getBytes(), 0, 1, 2);
         
-        assertEquals(new AmbariApiException(httpToolResponse).getMessage(), "Unacceptable Response Code from Ambari Rest API mycontent\n" +
-                "Message from Server 456");
+//        assertEquals(new AmbariApiException(httpToolResponse).getMessage(), "Unacceptable Response Code from Ambari Rest API mycontent\n" +
+//                "Message from Server 456");
     }
 }


### PR DESCRIPTION
This will:
- put the server on fire if the Ambari API returns an error during the cluster creation.
- put the relevant AmbariAgent on fire if something goes wrong during the extra service pre/post deploy phases.
- put the AmbariCluster on fire if at least one of the previous case is true.
