### PR TITLE
Cluster topology is now the same for the two types of deployments

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
@@ -107,12 +107,6 @@ public interface AmbariCluster extends Entity, Startable {
             ConfigKeys.newConfigKey(new TypeToken<List<String>>() {
             }, "ambari.stack.urls", "stack definitions as tar.gz", new LinkedList<String>());
 
-    AttributeSensor<AmbariServer> AMBARI_SERVER = Sensors.newSensor(
-            AmbariServer.class, "ambaricluster.configservers", "Config servers");
-
-    AttributeSensor<DynamicCluster> AMBARI_AGENTS = Sensors.newSensor(
-            DynamicCluster.class, "ambaricluster.configagents", "Config agents");
-
     AttributeSensor<Boolean> CLUSTER_SERVICES_INITIALISE_CALLED = Sensors.newBooleanSensor("ambari.cluster.servicesInitialiseCalled");
 
     AttributeSensor<Boolean> CLUSTER_SERVICES_INSTALLED = Sensors.newBooleanSensor("ambari.cluster.servicesInstalled");
@@ -139,6 +133,16 @@ public interface AmbariCluster extends Entity, Startable {
      * @return a collection of Ambari agents.
      */
     Iterable<AmbariAgent> getAmbariAgents();
+
+    /**
+     * Returns the first Ambari server installed on the cluster. This is fine for now as we support only one server
+     * for the entire hadoop cluster and therefore, this method will always return the same result.
+     *
+     * TODO: This however will need to be changed to properly handle a "cluster of server" once HA will be implemented
+     *
+     * @return the first Ambari server.
+     */
+    AmbariServer getMasterAmbariServer();
 
     /**
      * Configure and deploy a new Hadoop cluster on the registered Ambari agents.

--- a/ambari/src/main/java/io/brooklyn/ambari/agent/AmbariAgentImpl.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/agent/AmbariAgentImpl.java
@@ -75,10 +75,10 @@ public class AmbariAgentImpl extends SoftwareProcessImpl implements AmbariAgent 
         return getAttribute(COMPONENTS);
     }
 
-    public static EntitySpec<? extends AmbariAgent> createAgentSpec(Entity ambariCluster, ConfigBag configBag) {
+    public static EntitySpec<? extends AmbariAgent> createAgentSpec(AmbariCluster ambariCluster, ConfigBag configBag) {
         EntitySpec<? extends AmbariAgent> agentSpec = EntitySpec.create(ambariCluster.getConfig(AmbariCluster.AGENT_SPEC))
                 .configure(AMBARI_SERVER_FQDN,
-                        attributeWhenReady(ambariCluster.getAttribute(AmbariCluster.AMBARI_SERVER), FQDN))
+                        attributeWhenReady(ambariCluster.getMasterAmbariServer(), FQDN))
                 .configure(SoftwareProcess.SUGGESTED_VERSION,
                         ambariCluster.getConfig(AmbariCluster.SUGGESTED_VERSION));
         if (configBag != null) {

--- a/ambari/src/main/java/io/brooklyn/ambari/hostgroup/AmbariHostGroupImpl.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/hostgroup/AmbariHostGroupImpl.java
@@ -24,6 +24,8 @@ import brooklyn.entity.basic.SameServerEntity;
 import brooklyn.entity.group.DynamicClusterImpl;
 import brooklyn.entity.proxying.EntitySpec;
 import com.google.common.collect.ImmutableList;
+
+import io.brooklyn.ambari.AmbariCluster;
 import io.brooklyn.ambari.agent.AmbariAgent;
 import io.brooklyn.ambari.agent.AmbariAgentImpl;
 import org.slf4j.Logger;
@@ -65,7 +67,7 @@ public class AmbariHostGroupImpl extends DynamicClusterImpl implements AmbariHos
     }
 
     private EntitySpec<? extends AmbariAgent> ambariAgentSpec() {
-        return AmbariAgentImpl.createAgentSpec(getParent(), config().getLocalBag());
+        return AmbariAgentImpl.createAgentSpec((AmbariCluster) getParent(), config().getLocalBag());
     }
 
     private EntitySpec agentWithSiblingsSpec(EntitySpec<?> siblingSpec) {


### PR DESCRIPTION
This create the same structure within the Brooklyn web console whether or not the the Ambari cluster is services or host group based.
