### PR TITLE
Update the repositories installation URLs

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
@@ -89,7 +89,7 @@ public interface AmbariCluster extends Entity, Startable {
     ConfigKey<AttributeSensor<String>> ETC_HOST_ADDRESS = AmbariConfigAndSensors.ETC_HOST_ADDRESS;
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.7.0");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.1.2");
 
     @SetFromFlag("serverComponents")
     ConfigKey<List<String>> SERVER_COMPONENTS =


### PR DESCRIPTION
This updates the URLs as well as the supported OS, based on https://cwiki.apache.org/confluence/display/AMBARI/Install+Ambari+2.1.2+from+Public+Repositories. It also uses the latest Ambari release by default (2.1.2)

This does not take care of validating the configuration (combination of provisioning properties + Ambari version) I can add it if there is a strong feeling about it.
