### PR TITLE
Fix wrong number of host groups created during a services based deployment

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariClusterImpl.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariClusterImpl.java
@@ -528,7 +528,15 @@ public class AmbariClusterImpl extends BasicStartableImpl implements AmbariClust
     }
 
     private void createClusterTopology() {
-        for (int i = 0; i < getAttribute(EXPECTED_AGENTS); i++) {
+        int totalHostGroup = getAttribute(EXPECTED_AGENTS);
+        // getAttribute(EXPECTED_AGENTS) = number of agents defined + agent on server. As createClusterTopology()
+        // is called only for services based deployment, we need to remove the agent installed on the server from the
+        // total count.
+        if (getMasterAmbariServer().agentOnServer()) {
+            totalHostGroup--;
+        }
+
+        for (int i = 0; i < totalHostGroup; i++) {
             addChild(EntitySpec.create(AmbariHostGroup.class)
                     .configure(AmbariHostGroup.INITIAL_SIZE, 1)
                     .displayName(String.format("host-group-%d", (i + 1))));


### PR DESCRIPTION
The number of host groups created during a services based deployment is based on the number of expected agents. However, this number take into account the agent installed on the server (if exists).

This change will remove this agent from the total count to have the correct number of expected host groups.
