### PR TITLE
Update AmbariCluster.java

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
@@ -111,7 +111,7 @@ public interface AmbariCluster extends BasicStartable {
     ConfigKey<AttributeSensor<String>> ETC_HOST_ADDRESS = AmbariConfigAndSensors.ETC_HOST_ADDRESS;
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.1.2");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.2.0.0");
 
     @SetFromFlag("serverComponents")
     ConfigKey<List<String>> SERVER_COMPONENTS =


### PR DESCRIPTION
Bumped default version to `2.2.0.0` to avoid ZKFC issue with Ambari
