### PR TITLE
Ambari Version 2.4.2

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/agent/AmbariAgentSshDriver.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/agent/AmbariAgentSshDriver.java
@@ -24,6 +24,7 @@ import static org.apache.brooklyn.util.ssh.BashCommands.sudo;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.entity.java.JavaSoftwareProcessSshDriver;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
@@ -95,6 +96,9 @@ public class AmbariAgentSshDriver extends JavaSoftwareProcessSshDriver implement
                         .add(defaultAmbariInstallHelper.installAmbariRequirements(getMachine()))
                         .addAll(BashCommands.setHostname(fqdn))
                         .add(installPackage("ambari-agent"))
+                        .add(BashCommands.appendToEtcHosts(
+                                getParentAmbariCluster().getMasterAmbariServer().sensors().get(Attributes.SUBNET_ADDRESS),
+                                getEntity().getAmbariServerFQDN()))
                         .build();
 
         newScript(INSTALLING).body
@@ -126,4 +130,9 @@ public class AmbariAgentSshDriver extends JavaSoftwareProcessSshDriver implement
         return entity.getConfig(AmbariAgent.TEMPLATE_CONFIGURATION_URL);
     }
 
+    protected AmbariCluster getParentAmbariCluster() {
+        Iterable<AmbariCluster> ancestors = Iterables.filter(
+                Entities.ancestors(entity), AmbariCluster.class);
+        return Iterables.getFirst(ancestors, null);
+    }
 }

--- a/ambari/src/main/resources/io/brooklyn/ambari/agent/ambari-agent.ini
+++ b/ambari/src/main/resources/io/brooklyn/ambari/agent/ambari-agent.ini
@@ -18,6 +18,8 @@ url_port=8440
 secured_url_port=8441
 
 [agent]
+logdir=/var/log/ambari-agent
+piddir=/var/run/ambari-agent
 prefix=/var/lib/ambari-agent/data
 tmp_dir=/var/lib/ambari-agent/data/tmp
 ;loglevel=(DEBUG/INFO)
@@ -28,6 +30,14 @@ data_cleanup_max_size_MB = 100
 ping_port=8670
 cache_dir=/var/lib/ambari-agent/cache
 tolerate_download_failures=true
+run_as_user=root
+parallel_execution=0
+alert_grace_period=5
+alert_kinit_timeout=14400000
+system_resource_overrides=/etc/resource_overrides
+; memory_threshold_soft_mb=400
+; memory_threshold_hard_mb=1000
+tolerate_download_failures=true
 
 [command]
 maxretries=2
@@ -37,12 +47,13 @@ sleepBetweenRetries=1
 keysdir=/var/lib/ambari-agent/keys
 server_crt=ca.crt
 passphrase_env_var_name=AMBARI_PASSPHRASE
+ssl_verify_cert=0
 
 [services]
 pidLookupPath=/var/run/
 
 [heartbeat]
-state_interval=6
+state_interval_seconds=60
 dirs=/etc/hadoop,/etc/hadoop/conf,/etc/hbase,/etc/hcatalog,/etc/hive,/etc/oozie,
      /etc/sqoop,/etc/ganglia,/etc/nagios,
      /var/run/hadoop,/var/run/zookeeper,/var/run/hbase,/var/run/templeton,/var/run/oozie,
@@ -50,3 +61,8 @@ dirs=/etc/hadoop,/etc/hadoop/conf,/etc/hbase,/etc/hcatalog,/etc/hive,/etc/oozie,
      /var/log/nagios
 ; 0 - unlimited
 log_lines_count=300
+idle_interval_min=1
+idle_interval_max=10
+
+[logging]
+syslog_enabled=0


### PR DESCRIPTION
I tested this implementation on aws with the following blueprint:

    location:
      aws-ec2:eu-central-1:
        minRam: 8192
        osFamily: ubuntu
        osVersionRegex: 14.*

    services:
    - type: io.brooklyn.ambari.AmbariCluster
      name: Ambari Cluster
      brooklyn.config:
        version: 2.4.2.0
        stackVersion: 2.5
        securityGroup: test-ambari
        initialSize: 3
        services:
        - FALCON
        - FLUME
        - GANGLIA
        - HBASE
        - HDFS
        - KAFKA
        - KERBEROS
        - MAPREDUCE2
        - NAGIOS
        - OOZIE
        - PIG
        - SLIDER
        - SQOOP
        - STORM
        - TEZ
        - YARN
        - ZOOKEEPER