### PR TITLE
Config key defaults immutable

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
@@ -54,34 +54,56 @@ public interface AmbariCluster extends BasicStartable {
     @SetFromFlag("initialSize")
     ConfigKey<Integer> INITIAL_SIZE = ConfigKeys.newConfigKeyWithDefault(Cluster.INITIAL_SIZE, 0);
 
-    AttributeSensor<Integer> EXPECTED_AGENTS = Sensors.newIntegerSensor("ambaricluster.expectedservers", "Number of ambari agents expected to register with cluster");
+    AttributeSensor<Integer> EXPECTED_AGENTS = Sensors.newIntegerSensor(
+            "ambaricluster.expectedservers", 
+            "Number of ambari agents expected to register with cluster");
 
     @SetFromFlag("blueprint.name")
-    ConfigKey<String> BLUEPRINT_NAME = ConfigKeys.newStringConfigKey("blueprint.name", "Ambari Blueprint name", "mybp");
+    ConfigKey<String> BLUEPRINT_NAME = ConfigKeys.newStringConfigKey(
+            "blueprint.name", 
+            "Ambari Blueprint name", 
+            "mybp");
 
     @SetFromFlag("cluster.name")
-    ConfigKey<String> CLUSTER_NAME = ConfigKeys.newStringConfigKey("cluster.name", "Ambari Cluster name", "Cluster1");
+    ConfigKey<String> CLUSTER_NAME = ConfigKeys.newStringConfigKey(
+            "cluster.name", 
+            "Ambari Cluster name", 
+            "Cluster1");
 
     @SetFromFlag("securityGroup")
-    ConfigKey<String> SECURITY_GROUP = ConfigKeys.newStringConfigKey("securityGroup", "Security group to be shared by agents and server");
+    ConfigKey<String> SECURITY_GROUP = ConfigKeys.newStringConfigKey(
+            "securityGroup", 
+            "Security group to be shared by agents and server");
 
     @SetFromFlag("services")
-    ConfigKey<List<String>> HADOOP_SERVICES = ConfigKeys.newConfigKey(new TypeToken<List<String>>() {
-    }, "services", "List of services to deploy to Hadoop Cluster");
+    @SuppressWarnings("serial")
+    ConfigKey<List<String>> HADOOP_SERVICES = ConfigKeys.newConfigKey(
+            new TypeToken<List<String>>() {}, 
+            "services", 
+            "List of services to deploy to Hadoop Cluster");
 
     @SetFromFlag("stackName")
-    ConfigKey<String> HADOOP_STACK_NAME = ConfigKeys.newStringConfigKey("stackName", "Hadoop stack name", "HDP");
+    ConfigKey<String> HADOOP_STACK_NAME = ConfigKeys.newStringConfigKey(
+            "stackName", 
+            "Hadoop stack name", 
+            "HDP");
 
     @SetFromFlag("stackVersion")
-    ConfigKey<String> HADOOP_STACK_VERSION = ConfigKeys.newStringConfigKey("stackVersion", "Hadoop stack version", "2.3");
+    ConfigKey<String> HADOOP_STACK_VERSION = ConfigKeys.newStringConfigKey(
+            "stackVersion", 
+            "Hadoop stack version", 
+            "2.3");
 
     @SetFromFlag("repoBaseUrl")
-    ConfigKey<? extends String> REPO_BASE_URL = ConfigKeys.newStringConfigKey("repository.base.url", "The base url of the ambari repo", "http://public-repo-1.hortonworks.com");
+    ConfigKey<? extends String> REPO_BASE_URL = ConfigKeys.newStringConfigKey(
+            "repository.base.url", 
+            "The base url of the ambari repo", 
+            "http://public-repo-1.hortonworks.com");
 
     @Deprecated
     @SetFromFlag("extraServices")
-    ConfigKey<List<EntitySpec<? extends ExtraService>>> EXTRA_HADOOP_SERVICES = BasicConfigKey.builder(new TypeToken<List<EntitySpec<? extends ExtraService>>>() {
-    })
+    @SuppressWarnings("serial")
+    ConfigKey<List<EntitySpec<? extends ExtraService>>> EXTRA_HADOOP_SERVICES = BasicConfigKey.builder(new TypeToken<List<EntitySpec<? extends ExtraService>>>() {})
             .name("extraServices")
             .description("List of extra services to deploy to Hadoop Cluster " +
                     "NB: this configuration parameter doesn't work in yaml")
@@ -90,20 +112,18 @@ public interface AmbariCluster extends BasicStartable {
 
     @Deprecated
     @SetFromFlag("extraService")
-    ConfigKey<EntitySpec<? extends ExtraService>> EXTRA_HADOOP_SERVICE = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends ExtraService>>() {
-    })
+    ConfigKey<EntitySpec<? extends ExtraService>> EXTRA_HADOOP_SERVICE = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends ExtraService>>() {})
             .name("extraService")
             .description("List of extra services to deploy to Hadoop Cluster")
             .build();
 
-    ConfigKey<EntitySpec<? extends AmbariServer>> SERVER_SPEC = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends AmbariServer>>() {
-    }).name("ambaricluster.serverspec")
+    ConfigKey<EntitySpec<? extends AmbariServer>> SERVER_SPEC = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends AmbariServer>>() {})
+            .name("ambaricluster.serverspec")
             .defaultValue(EntitySpec.create(AmbariServer.class))
             .build();
 
-    ConfigKey<EntitySpec<? extends AmbariAgent>> AGENT_SPEC = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends AmbariAgent>>() {
-    }
-    ).name("ambaricluster.agentspec")
+    ConfigKey<EntitySpec<? extends AmbariAgent>> AGENT_SPEC = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends AmbariAgent>>() {})
+            .name("ambaricluster.agentspec")
             .defaultValue(EntitySpec.create(AmbariAgent.class))
             .build();
 
@@ -114,34 +134,44 @@ public interface AmbariCluster extends BasicStartable {
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.2.0.0");
 
     @SetFromFlag("serverComponents")
-    ConfigKey<List<String>> SERVER_COMPONENTS =
-            ConfigKeys.newConfigKey(
-                    new TypeToken<List<String>>() {
-                    }, "ambari.server.components", "List of components to install on Ambari Server.  " +
-                            "If non-empty then ambari agent will be added to server", new LinkedList<String>());
+    ConfigKey<List<String>> SERVER_COMPONENTS = ConfigKeys.newConfigKey(
+            new TypeToken<List<String>>() {}, 
+            "ambari.server.components", 
+            "List of components to install on Ambari Server.  "
+                    + "If non-empty then ambari agent will be added to server", 
+            new LinkedList<String>());
 
     @SetFromFlag("ambariConfigMap")
-    ConfigKey<Map<String, Map>> AMBARI_CONFIGURATIONS =
-            new MapConfigKey<Map>(Map.class, "ambari.configurations", "Map of maps");
+    ConfigKey<Map<String, Map>> AMBARI_CONFIGURATIONS = new MapConfigKey<Map>(
+            Map.class, 
+            "ambari.configurations", ""
+                    + "Map of maps");
 
     @SetFromFlag("ambariStackDefsUrls")
-    ConfigKey<List<String>> STACK_DEFINITION_URLS =
-            ConfigKeys.newConfigKey(new TypeToken<List<String>>() {
-            }, "ambari.stack.urls", "stack definitions as tar.gz", new LinkedList<String>());
+    ConfigKey<List<String>> STACK_DEFINITION_URLS = ConfigKeys.newConfigKey(
+            new TypeToken<List<String>>() {}, 
+            "ambari.stack.urls", 
+            "stack definitions as tar.gz", 
+            new LinkedList<String>());
 
     @SetFromFlag("pauseForDeployment")
-    ConfigKey<Boolean> PAUSE_FOR_DEPLOYMENT =
-            ConfigKeys.newBooleanConfigKey(
-                    "ambari.pause.before.deployment",
-                    "Pauses once ambari server and clusters ready to deploy.  Creates deployCluster " +
-                            "effector to continue deployment",
-                    Boolean.FALSE);
+    ConfigKey<Boolean> PAUSE_FOR_DEPLOYMENT = ConfigKeys.newBooleanConfigKey(
+            "ambari.pause.before.deployment",
+            "Pauses once ambari server and clusters ready to deploy.  Creates deployCluster "
+                    + "effector to continue deployment",
+            Boolean.FALSE);
 
     @SetFromFlag("domainName")
-    ConfigKey<String> DOMAIN_NAME = ConfigKeys.newStringConfigKey("ambari.domain.name", "Domain name to use for all hosts FQDNs", "ambari.local");
+    ConfigKey<String> DOMAIN_NAME = ConfigKeys.newStringConfigKey(
+            "ambari.domain.name", 
+            "Domain name to use for all hosts FQDNs", 
+            "ambari.local");
 
     @SetFromFlag("serverHostGroup")
-    ConfigKey<String> SERVER_HOST_GROUP = ConfigKeys.newStringConfigKey("ambari.server.hostgroup.name", "Host group name for the agent on the Ambari server", "server-group");
+    ConfigKey<String> SERVER_HOST_GROUP = ConfigKeys.newStringConfigKey(
+            "ambari.server.hostgroup.name", 
+            "Host group name for the agent on the Ambari server", 
+            "server-group");
 
     AttributeSensor<Boolean> CLUSTER_SERVICES_INITIALISE_CALLED = Sensors.newBooleanSensor("ambari.cluster.servicesInitialiseCalled");
 
@@ -153,9 +183,10 @@ public interface AmbariCluster extends BasicStartable {
     String AMBARI_ALERTS_NOTIFICATION_PROPERTIES_PREFIX = "properties.";
 
     @SetFromFlag("ambariAlertNotifications")
-    ConfigKey<Map<String, Object>> AMBARI_ALERT_NOTIFICATIONS =
-            new MapConfigKey(Map.class, Strings.removeFromEnd(AMBARI_ALERTS_CONFIG_PREFIX, "."),
-                    "Map compatible with Ambari requirements for creating/editing alert notification request");
+    ConfigKey<Map<String, Object>> AMBARI_ALERT_NOTIFICATIONS = new MapConfigKey(
+            Map.class, 
+            Strings.removeFromEnd(AMBARI_ALERTS_CONFIG_PREFIX, "."),
+            "Map compatible with Ambari requirements for creating/editing alert notification request");
 
 
     List<String> AMBARI_ALERTS_NOTIFICATION_LIST_KEYS = ImmutableList.of(

--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariCluster.java
@@ -19,7 +19,6 @@
 
 package io.brooklyn.ambari;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -107,7 +106,7 @@ public interface AmbariCluster extends BasicStartable {
             .name("extraServices")
             .description("List of extra services to deploy to Hadoop Cluster " +
                     "NB: this configuration parameter doesn't work in yaml")
-            .defaultValue(new LinkedList<EntitySpec<? extends ExtraService>>())
+            .defaultValue(ImmutableList.<EntitySpec<? extends ExtraService>>of())
             .build();
 
     @Deprecated
@@ -119,12 +118,12 @@ public interface AmbariCluster extends BasicStartable {
 
     ConfigKey<EntitySpec<? extends AmbariServer>> SERVER_SPEC = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends AmbariServer>>() {})
             .name("ambaricluster.serverspec")
-            .defaultValue(EntitySpec.create(AmbariServer.class))
+            .defaultValue(EntitySpec.create(AmbariServer.class).immutable())
             .build();
 
     ConfigKey<EntitySpec<? extends AmbariAgent>> AGENT_SPEC = BasicConfigKey.builder(new TypeToken<EntitySpec<? extends AmbariAgent>>() {})
             .name("ambaricluster.agentspec")
-            .defaultValue(EntitySpec.create(AmbariAgent.class))
+            .defaultValue(EntitySpec.create(AmbariAgent.class).immutable())
             .build();
 
     @SetFromFlag("hostAddressSensor")
@@ -139,7 +138,7 @@ public interface AmbariCluster extends BasicStartable {
             "ambari.server.components", 
             "List of components to install on Ambari Server.  "
                     + "If non-empty then ambari agent will be added to server", 
-            new LinkedList<String>());
+            ImmutableList.<String>of());
 
     @SetFromFlag("ambariConfigMap")
     ConfigKey<Map<String, Map>> AMBARI_CONFIGURATIONS = new MapConfigKey<Map>(
@@ -152,7 +151,7 @@ public interface AmbariCluster extends BasicStartable {
             new TypeToken<List<String>>() {}, 
             "ambari.stack.urls", 
             "stack definitions as tar.gz", 
-            new LinkedList<String>());
+            ImmutableList.<String>of());
 
     @SetFromFlag("pauseForDeployment")
     ConfigKey<Boolean> PAUSE_FOR_DEPLOYMENT = ConfigKeys.newBooleanConfigKey(

--- a/ambari/src/main/java/io/brooklyn/ambari/AmbariConfigAndSensors.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/AmbariConfigAndSensors.java
@@ -32,9 +32,9 @@ public class AmbariConfigAndSensors {
     /**
      * Sets the sensor to use to configure addresses in machines' /etc/hosts file.
      */
+    @SuppressWarnings("serial")
     public static final ConfigKey<AttributeSensor<String>> ETC_HOST_ADDRESS = ConfigKeys.newConfigKey(
-            new TypeToken<AttributeSensor<String>>() {
-            },
+            new TypeToken<AttributeSensor<String>>() {},
             "entity.hostAddressSensor", "The sensor to use to obtain addresses for each machine's host file",
             Attributes.SUBNET_ADDRESS);
 }

--- a/ambari/src/main/java/io/brooklyn/ambari/agent/AmbariAgent.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/agent/AmbariAgent.java
@@ -41,14 +41,17 @@ public interface AmbariAgent extends AmbariNode {
 
     @SetFromFlag("configFileUrl")
     ConfigKey<String> TEMPLATE_CONFIGURATION_URL = ConfigKeys.newConfigKey(
-            "ambari.templateConfigurationUrl", "Template file (in freemarker format) for the ambari-agent.ini file",
+            "ambari.templateConfigurationUrl", 
+            "Template file (in freemarker format) for the ambari-agent.ini file",
             JavaClassNames.resolveClasspathUrl(AmbariAgent.class, "ambari-agent.ini"));
 
     @SetFromFlag("ambariServerFQDN")
     ConfigKey<String> AMBARI_SERVER_FQDN = ConfigKeys.newStringConfigKey(
-            "ambari.server.fqdn", "Fully Qualified Domain Name of ambari server that agent should register to");
+            "ambari.server.fqdn", 
+            "Fully Qualified Domain Name of ambari server that agent should register to");
 
 
+    @SuppressWarnings("serial")
     AttributeSensor<List<String>> COMPONENTS = Sensors.newSensor(
             new TypeToken<List<String>>() {},
             "hadoop.components",

--- a/ambari/src/main/java/io/brooklyn/ambari/hostgroup/AmbariHostGroup.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/hostgroup/AmbariHostGroup.java
@@ -35,13 +35,19 @@ import com.google.common.reflect.TypeToken;
 public interface AmbariHostGroup extends DynamicCluster {
 
     @SetFromFlag("components")
-    ConfigKey<List<String>> HADOOP_COMPONENTS = ConfigKeys.newConfigKey(new TypeToken<List<String>>() {
-    }, "components", "List of components to deploy to host group");
+    @SuppressWarnings("serial")
+    ConfigKey<List<String>> HADOOP_COMPONENTS = ConfigKeys.newConfigKey(
+            new TypeToken<List<String>>() {}, 
+            "components", 
+            "List of components to deploy to host group");
 
     @SetFromFlag("siblingSpec")
+    @SuppressWarnings("serial")
     ConfigKey<EntitySpec<?>> SIBLING_SPEC = ConfigKeys.newConfigKey(
             new TypeToken<EntitySpec<?>>(){},
-            "ambari.sibling.spec", "Spec for  extra entity to be installed on each of nodes in cluster", null);
+            "ambari.sibling.spec", 
+            "Spec for  extra entity to be installed on each of nodes in cluster", 
+            null);
 
     List<String> getHostFQDNs();
 

--- a/ambari/src/main/java/io/brooklyn/ambari/server/AmbariServer.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/server/AmbariServer.java
@@ -44,12 +44,14 @@ import io.brooklyn.ambari.rest.domain.Request;
 public interface AmbariServer extends AmbariNode {
 
     // TODO this value is read-only; changing its config value is not reflected in the deployed artifacts!
-    PortAttributeSensorAndConfigKey HTTP_PORT =
-            new PortAttributeSensorAndConfigKey("ambari.server.httpPort", "HTTP Port", "8080");
+    PortAttributeSensorAndConfigKey HTTP_PORT = new PortAttributeSensorAndConfigKey(
+                    "ambari.server.httpPort", 
+                    "HTTP Port", 
+                    "8080");
 
+    @SuppressWarnings("serial")
     AttributeSensor<List<String>> REGISTERED_HOSTS = Sensors.newSensor(
-            new TypeToken<List<String>>() {
-            },
+            new TypeToken<List<String>>() {},
             "ambari.server.registeredHosts",
             "List of registered agent names");
 
@@ -57,10 +59,14 @@ public interface AmbariServer extends AmbariNode {
 
     AttributeSensor<String> CLUSTER_STATE = Sensors.newStringSensor("ambari.server.clusterState");
 
-    AttributeSensor<String> USERNAME = Sensors.newStringSensor("ambari.server.http.user", "Ambari Server's http username.");
+    AttributeSensor<String> USERNAME = Sensors.newStringSensor(
+            "ambari.server.http.user", 
+            "Ambari Server's http username.");
 
     BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey PASSWORD =
-            new BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey("ambari.server.http.password", "Ambari Server's http password");
+            new BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey(
+                    "ambari.server.http.password", 
+                    "Ambari Server's http password");
 
     /**
      * @throws IllegalStateException if times out.

--- a/ambari/src/main/java/io/brooklyn/ambari/service/CustomService.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/service/CustomService.java
@@ -33,28 +33,38 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 @ImplementedBy(CustomServiceImpl.class)
 public interface CustomService extends ExtraService {
     @SetFromFlag("customServiceName")
-    ConfigKey<String> CUSTOM_SERVICE_NAME = ConfigKeys.newStringConfigKey("custom.service.name", "Name of the custom service");
+    ConfigKey<String> CUSTOM_SERVICE_NAME = ConfigKeys.newStringConfigKey(
+            "custom.service.name", 
+            "Name of the custom service");
     
     @SetFromFlag("customServiceConfig")
-    ConfigKey<Map<String, Map>> CUSTOM_SERVICE_CONF = new MapConfigKey<Map>(Map.class, "custom.service.config", "Service Configuration as Map of maps");
+    ConfigKey<Map<String, Map>> CUSTOM_SERVICE_CONF = new MapConfigKey<Map>(
+            Map.class, 
+            "custom.service.config", 
+            "Service Configuration as Map of maps");
 
     @SetFromFlag("serviceConfigTemplateUrl")
     ConfigKey<String> SERVICE_CONFIG_TEMPLATE_URL = ConfigKeys.newStringConfigKey(
-            "service.config.templateUrl", "Template file (in freemarker format) for the custom service's service-config.xml file", 
+            "service.config.templateUrl", 
+            "Template file (in freemarker format) for the custom service's service-config.xml file", 
             "classpath://io/brooklyn/ambari/service/custom/configuration/service-config.xml");
 
     @SetFromFlag("serviceConfigTemplateUrl")
     ConfigKey<String> SERVICE_SCRIPT_TEMPLATE_URL = ConfigKeys.newStringConfigKey(
-            "service.script.templateUrl", "Template file (in freemarker format) for the custom service's python script file", 
+            "service.script.templateUrl", 
+            "Template file (in freemarker format) for the custom service's python script file", 
             "classpath://io/brooklyn/ambari/service/custom/package/scripts/service_client.py");
 
     @SetFromFlag("serviceConfigTemplateUrl")
     ConfigKey<String> SERVICE_METAINFO_TEMPLATE_URL = ConfigKeys.newStringConfigKey(
-            "service.metainfo.templateUrl", "Template file (in freemarker format) for the custom service's metainfo.xml file", 
+            "service.metainfo.templateUrl", 
+            "Template file (in freemarker format) for the custom service's metainfo.xml file", 
             "classpath://io/brooklyn/ambari/service/custom/metainfo.xml");
 
     @SetFromFlag("customCcomponentName")
-    ConfigKey<String> CUSTOM_COMPONENT_NAME = ConfigKeys.newStringConfigKey("custom.component.name", "Name of the componentName");
+    ConfigKey<String> CUSTOM_COMPONENT_NAME = ConfigKeys.newStringConfigKey(
+            "custom.component.name", 
+            "Name of the componentName");
 
     void customizeService();
 }

--- a/ambari/src/main/java/io/brooklyn/ambari/service/ExtraService.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/service/ExtraService.java
@@ -88,20 +88,25 @@ public interface ExtraService extends BasicStartable {
     }
 
     @SetFromFlag("bindTo")
-    ConfigKey<String> BIND_TO = ConfigKeys.newStringConfigKey("bindTo", "Name of component which will be use to determine the host to install RANGER");
+    ConfigKey<String> BIND_TO = ConfigKeys.newStringConfigKey(
+            "bindTo", 
+            "Name of component which will be use to determine the host to install RANGER");
 
     @SetFromFlag("serviceName")
-    ConfigKey<String> SERVICE_NAME = ConfigKeys.newStringConfigKey("serviceName", "Name of the Hadoop service, identified by Ambari");
+    ConfigKey<String> SERVICE_NAME = ConfigKeys.newStringConfigKey(
+            "serviceName", 
+            "Name of the Hadoop service, identified by Ambari");
 
     @SetFromFlag("componentNames")
+    @SuppressWarnings("serial")
     ConfigKey<List<String>> COMPONENT_NAMES =
             ConfigKeys.newConfigKey(
                     new TypeToken<List<String>>() {},
                     "componentNames",
-                    "List of component names for this Hadoop service, identified by Ambari. " +
-                    "Items should be of form <component>|<hostGroup> or simply " +
-                    "<component>.  If hostgroup is omitted it is assumed that the " +
-                    "component should be installed on the bound hostgroup.");
+                    "List of component names for this Hadoop service, identified by Ambari. "
+                            + "Items should be of form <component>|<hostGroup> or simply "
+                            + "<component>.  If hostgroup is omitted it is assumed that the "
+                            + "component should be installed on the bound hostgroup.");
 
     /**
      * Returns the list of mapping <component-name> <--> <host-group-name> for this extra service.

--- a/ambari/src/main/java/io/brooklyn/ambari/service/Ranger.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/service/Ranger.java
@@ -31,11 +31,20 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public interface Ranger extends ExtraService {
 
     @SetFromFlag("dbUser")
-    ConfigKey<String> DB_USER = ConfigKeys.newStringConfigKey("db.user", "MySQL user", "ranger");
+    ConfigKey<String> DB_USER = ConfigKeys.newStringConfigKey(
+            "db.user", 
+            "MySQL user", 
+            "ranger");
 
     @SetFromFlag("dbPassword")
-    ConfigKey<String> DB_PASSWORD = ConfigKeys.newStringConfigKey("db.password", "MySQL user password", "rangerpassword");
+    ConfigKey<String> DB_PASSWORD = ConfigKeys.newStringConfigKey(
+            "db.password", 
+            "MySQL user password", 
+            "rangerpassword");
 
     @SetFromFlag("rangerPassword")
-    ConfigKey<String> RANGER_PASSWORD = ConfigKeys.newStringConfigKey("ranger.password", "Ranger user password", "rangerpassword");
+    ConfigKey<String> RANGER_PASSWORD = ConfigKeys.newStringConfigKey(
+            "ranger.password", 
+            "Ranger user password", 
+            "rangerpassword");
 }


### PR DESCRIPTION
See separate commits - the first just tidies up the code; the second actually fixes the issue.

It's really important that config key defaults are immutable. Otherwise a blueprint could modify it, which would affect the behaviour of subsequently deployed blueprints!