### PR TITLE
Uses generic notUpIndicator key for AbstractExtraServicesTask

### DIFF
--- a/ambari/src/main/java/io/brooklyn/ambari/service/AbstractExtraServicesTask.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/service/AbstractExtraServicesTask.java
@@ -31,8 +31,10 @@ import com.google.common.base.Function;
 
 public abstract class AbstractExtraServicesTask<T extends Entity> implements Function<T, Void> {
 
-    protected String errorKey = "ranger.mysql";
-    protected String errorDescription = "Error initialising Ranger requirements";
+    // TODO: At some point these should really be replaced with abstract functions, but that would need
+    // to be co-ordinated with downstream
+    protected String errorKey = "extra.service.task";
+    protected String errorDescription = "Error initialising " + this;
 
     public abstract Task<Integer> sshTaskApply(T node);
 

--- a/ambari/src/main/java/io/brooklyn/ambari/service/RangerImpl.java
+++ b/ambari/src/main/java/io/brooklyn/ambari/service/RangerImpl.java
@@ -124,6 +124,9 @@ public class RangerImpl extends AbstractExtraService implements Ranger {
 
     class AmbariServerRequirementsFunction extends AbstractExtraServicesTask<AmbariServer> {
 
+        protected String errorKey = "ranger.ambari.server";
+        protected String errorDescription = "Error initialising Ranger requirements";
+
         @Override
         public Task<Integer> sshTaskApply(AmbariServer ambariServer) {
             return SshEffectorTasks
@@ -139,6 +142,9 @@ public class RangerImpl extends AbstractExtraService implements Ranger {
 
     class AmbariAgentRequirementsFunction extends AbstractExtraServicesTask<AmbariAgent> {
 
+        protected String errorKey = "ranger.ambari.agent";
+        protected String errorDescription = "Error initialising Ranger requirements";
+
         @Override
         public Task<Integer> sshTaskApply(AmbariAgent ambariAgent) {
 
@@ -152,6 +158,10 @@ public class RangerImpl extends AbstractExtraService implements Ranger {
     }
 
     class MysqlRequirementsFunction extends AbstractExtraServicesTask<AmbariAgent> {
+
+        protected String errorKey = "ranger.mysql";
+        protected String errorDescription = "Error initialising Ranger requirements";
+
         @Override
         public Task<Integer> sshTaskApply(AmbariAgent ambariAgent) {
 


### PR DESCRIPTION
Uses generic serviceNotUpIndicator key for AbstractExtraServicesTask, rather than misleading `ranger.mysql`key