### PR TITLE
Update HDP stack version to 2.6

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -45,7 +45,7 @@ brooklyn.catalog:
         brooklyn.config:
           initialSize: $brooklyn:config("ambari.cluster.nodes")
           version: 2.6.0.0
-          stackVersion: 2.5
+          stackVersion: 2.6
           securityGroup: test-ambari
           provisioning.properties:
             minRam: 8192
@@ -61,3 +61,4 @@ brooklyn.catalog:
           - MAPREDUCE2
           - YARN
           - ZOOKEEPER
+

--- a/catalog.bom
+++ b/catalog.bom
@@ -44,7 +44,7 @@ brooklyn.catalog:
         name: "Ambari cluster"
         brooklyn.config:
           initialSize: $brooklyn:config("ambari.cluster.nodes")
-          version: 2.4.2.0
+          version: 2.6.0.0
           stackVersion: 2.5
           securityGroup: test-ambari
           provisioning.properties:


### PR DESCRIPTION
Note: requires Ambari version bump; opted for latest stable at time of writing: confusingly also 2.6